### PR TITLE
fix: write log file directly to output folder

### DIFF
--- a/deep_cartograph/log_config/debug_configuration.ini
+++ b/deep_cartograph/log_config/debug_configuration.ini
@@ -30,4 +30,4 @@ args=(sys.stdout,)
 level=DEBUG
 class=FileHandler
 formatter=defaultFormatter
-args=('deep_cartograph.log', 'w')
+args=('%(log_path)s', 'w')

--- a/deep_cartograph/log_config/info_configuration.ini
+++ b/deep_cartograph/log_config/info_configuration.ini
@@ -30,4 +30,4 @@ args=(sys.stdout,)
 level=INFO
 class=FileHandler
 formatter=defaultFormatter
-args=('deep_cartograph.log', 'w')
+args=('%(log_path)s', 'w')

--- a/deep_cartograph/tools/analyze_geometry/analyze_geometry.py
+++ b/deep_cartograph/tools/analyze_geometry/analyze_geometry.py
@@ -173,33 +173,28 @@ def main():
 
     args = parser.parse_args()
 
-    # Set logger
-    set_logger(verbose=args.verbose)
-    
-    # Give value to output_folder
-    if args.output_folder is None:
-        output_folder = 'analyze_geometry'
-    else:
-        output_folder = args.output_folder
-        
-    # Create unique output directory
-    output_folder = get_unique_path(output_folder)
+    # Determine output folder, if restart is False, create a unique output folder
+    output_folder = args.output_folder if args.output_folder else 'analyze_geometry'
+    if not args.restart:
+        output_folder = get_unique_path(output_folder)
+    os.makedirs(output_folder, exist_ok=True)
 
+    # Set logger
+    log_path = os.path.join(output_folder, 'deep_cartograph.log')
+    set_logger(verbose=args.verbose, log_path=log_path)
+    
     # Read configuration
     configuration = read_configuration(args.configuration_path)
     
     # Check main input folders
     trajectories, topologies = check_data(args.trajectory_data, args.topology_data)
 
-    # Run tool
+    # Run Analyze Geometry tool
     _ = analyze_geometry(
         configuration = configuration, 
         trajectories = trajectories,
         topologies = topologies,
         output_folder = output_folder)
-
-    # Move log file to output folder
-    shutil.move('deep_cartograph.log', os.path.join(output_folder, 'deep_cartograph.log'))
 
 if __name__ == "__main__":
 

--- a/deep_cartograph/tools/compute_features/compute_features.py
+++ b/deep_cartograph/tools/compute_features/compute_features.py
@@ -225,15 +225,20 @@ def compute_features(
 
     return colvars_paths
 
-def set_logger(verbose: bool):
+def set_logger(verbose: bool, log_path: str):
     """
-    Function that sets the logging configuration. If verbose is True, it sets the logging level to DEBUG.
-    If verbose is False, it sets the logging level to INFO.
+    Configures logging for Deep Cartograph. 
+    
+    If `verbose` is `True`, sets the logging level to DEBUG.
+    Otherwise, sets it to INFO.
 
     Inputs
     ------
 
-        verbose (bool): If True, sets the logging level to DEBUG. If False, sets the logging level to INFO.
+    Args:
+        verbose (bool): If `True`, logging level is set to DEBUG. 
+                        If `False`, logging level is set to INFO.
+        log_path (str): Path to the log file where logs will be saved.
     """
     # Issue warning if logging is already configured
     if logging.getLogger().hasHandlers():
@@ -253,19 +258,20 @@ def set_logger(verbose: bool):
     # Check the existence of the configuration files
     if not os.path.exists(info_config_path):
         raise FileNotFoundError(f"Configuration file not found: {info_config_path}")
-    
     if not os.path.exists(debug_config_path):
         raise FileNotFoundError(f"Configuration file not found: {debug_config_path}")
     
-    if verbose:
-        logging.config.fileConfig(debug_config_path, disable_existing_loggers=True)
-    else:
-        logging.config.fileConfig(info_config_path, disable_existing_loggers=True)
+    # Pass the log_path to the fileConfig using the 'defaults' parameter
+    config_path = debug_config_path if verbose else info_config_path
+    logging.config.fileConfig(
+        config_path,
+        defaults={'log_path': log_path},
+        disable_existing_loggers=True
+    )
 
     logger = logging.getLogger("deep_cartograph")
-
     logger.info("Deep Cartograph: package for projecting and clustering trajectories using collective variables.")
-
+    
 def parse_arguments():
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -311,31 +317,26 @@ def main():
 
     args = parse_arguments()
 
-    # Set logger
-    set_logger(verbose=args.verbose)
+    # Determine output folder, if restart is False, create a unique output folder
+    output_folder = args.output_folder if args.output_folder else 'compute_features'
+    if not args.restart:
+        output_folder = get_unique_path(output_folder)
+    os.makedirs(output_folder, exist_ok=True)
     
-    # Give value to output_folder
-    if args.output_folder is None:
-        output_folder = 'compute_features'
-    else:
-        output_folder = args.output_folder
-        
-    # Create unique output directory
-    output_folder = get_unique_path(output_folder)
+    # Set logger
+    log_path = os.path.join(output_folder, 'deep_cartograph.log')
+    set_logger(verbose=args.verbose, log_path=log_path)
 
     # Read configuration
     configuration = read_configuration(args.configuration_path)
 
-    # Run tool
+    # Run Compute Features tool
     _ = compute_features(
         configuration = configuration, 
         trajectory = args.trajectory,
         topology = args.topology,
         colvars_path = args.colvars_path,
         output_folder = output_folder)
-
-    # Move log file to output folder
-    shutil.move('deep_cartograph.log', os.path.join(output_folder, 'deep_cartograph.log'))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
write log file directly to output folder to avoid race condition when running several instances of Deep Carto on the same working directory